### PR TITLE
独自ドメインを追加 #94

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.hosts << 'matchatasty.com'  # 独自ドメインを追加
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,5 +102,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.hosts << 'matchatasty.com'  # 独自ドメインを追加
+  config.hosts << "matchatasty.com"  # 独自ドメインを追加
 end


### PR DESCRIPTION
## 概要
Render の機能を用いて独自ドメインをアプリに反映し、DNS・SSL対応を行う。
URLの見栄えやサービスとしての信頼性を向上させる。

## 実装内容
- お名前.comで登録
- Render の設定画面から Custom Domain を追加
- 取得済み独自ドメインを登録
- ドメイン管理サービスお名前.comでCNAME/Aレコード設定
- アプリケーション側でホストの許可

## 関連Issue
Closes #94