### PR TITLE
パスワードリセットの画面デザイン調整 #38

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,28 @@
-<h2>Forgot your password?</h2>
+<%# パスワードリセット画面 %>
+<div class="max-w-md mx-auto mt-10">
+  <div class="card bg-white p-8 shadow-xl">
+    <h2 class="text-2xl font-bold mb-6 text-center">
+      パスワード再設定
+    </h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_with model: resource, as: resource_name, url: password_path(resource_name), class: "space-y-4", local: true do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <!-- メールアドレス -->
+      <div class="form-control">
+        <%= f.label :email, t('activerecord.attributes.user.email'), class: "label label-text font-semibold" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered w-full" %>
+        <label class="label">
+          <span class="label-text-alt text-gray-500">パスワード再設定用のリンクを送信します</span>
+        </label>
+      </div>
+
+      <!-- 送信ボタン -->
+      <%= f.submit t('devise.reset.new.send_me_reset_password_instructions'), class: "btn btn-primary w-full" %>
+    <% end %>
+
+    <div class="mt-4 text-center">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <span class="text-gray-400 text-sm cursor-not-allowed">パスワードをお忘れの場合（準備中）</span><br />
+  <%= link_to "パスワードをお忘れの場合", new_password_path(resource_name), class: "link link-primary" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -7,7 +7,7 @@
       <!-- メインタイトル -->
       <div class="mb-8">
         <h1 class="text-5xl md:text-6xl font-bold text-emerald-700 mb-4">
-          Matcha Tasty
+          MatchaTasty
         </h1>
         <p class="text-lg md:text-xl text-gray-600 max-w-2xl mx-auto leading-relaxed">
           抹茶スイーツに特化したレビュー・発見サービス。<br>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -4,6 +4,10 @@ ja:
       confirmed: "メールアドレスが確認できました。"
       send_instructions: "メールアドレス確認のメールを数分以内に送信します。"
       send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+    reset:
+      new:
+        forgot_your_password: 'パスワードをお忘れですか?'
+        send_me_reset_password_instructions: '確認メールを送信'
     failure:
       already_authenticated: "すでにログインしています。"
       inactive: "アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。"


### PR DESCRIPTION
## 概要
パスワードリセットの画面を daisyUI で統一感のあるデザインにする。

## 実装内容
- devise ビューに daisyUI を適用

## 関連Issue
Closes #38